### PR TITLE
Do not part from channels in destroy handler

### DIFF
--- a/src/idle-muc-channel.c
+++ b/src/idle-muc-channel.c
@@ -1355,9 +1355,6 @@ idle_muc_channel_destroy (
 
 	IDLE_DEBUG ("called on %p", self);
 
-	if (priv->state == MUC_STATE_JOINED)
-		part_from_channel (self, NULL);
-
 	/* FIXME: this is wrong if called while JOIN is in flight. */
 	if (priv->state < MUC_STATE_JOINED)
 		tp_base_channel_destroyed (base);


### PR DESCRIPTION
In case the client suddenly disappears (e.g. crashes) the user was
previously parted from the channels. This is terrible behaviour when the
user is using a bouncer, as they expect to stay in their channels. This
handler doesn't seem to be called on clean exit of clients, only when
they disappear suddenly.

This bug: https://bugs.freedesktop.org/show_bug.cgi?id=98685