### PR TITLE
Handle safe channels

### DIFF
--- a/src/idle-parser.c
+++ b/src/idle-parser.c
@@ -502,7 +502,9 @@ static gboolean _parse_atom(IdleParser *parser, GValueArray *arr, char atom, con
 			gchar *id, *bang = NULL;
 			gchar modechar = '\0';
 
-			if (idle_muc_channel_is_modechar(token[0])) {
+      /* Channel names can start with a '!', so don't strip that
+       * (https://tools.ietf.org/html/rfc2811#section-3.2) */
+			if (atom != 'r' && idle_muc_channel_is_modechar(token[0])) {
 				modechar = token[0];
 				token++;
 			}

--- a/src/idle-parser.c
+++ b/src/idle-parser.c
@@ -502,9 +502,13 @@ static gboolean _parse_atom(IdleParser *parser, GValueArray *arr, char atom, con
 			gchar *id, *bang = NULL;
 			gchar modechar = '\0';
 
-      /* Channel names can start with a '!', so don't strip that
-       * (https://tools.ietf.org/html/rfc2811#section-3.2) */
-			if (atom != 'r' && idle_muc_channel_is_modechar(token[0])) {
+			/* Channel names can start with a '!', so don't strip that
+			 * (https://tools.ietf.org/html/rfc2811#section-3.2), not
+			 * even when expecting a nickname (without mode chars) as
+			 * that ends up for example messing up PRIMSG handling and
+			 * showing the same message as both a channel and a private
+			 * message */
+			if (atom == 'C' && idle_muc_channel_is_modechar(token[0])) {
 				modechar = token[0];
 				token++;
 			}


### PR DESCRIPTION
Telepathy before this patch handles channels whose names start with `!` (safe channel, https://tools.ietf.org/html/rfc2811#section-3.2). They get connected (e.g. if the connection is server initiated via bouncer), but all the messages get parsed wrong. They appear as private messages from the individual people in the channel instead of as channel messages.

This doesn't have a corresponding bug at bugzilla, but I can create one if needed.