### PR TITLE
Allow `/` in nicknames to support common IRC bridges.

### DIFF
--- a/src/idle-handles.c
+++ b/src/idle-handles.c
@@ -69,6 +69,12 @@ gboolean idle_nickname_is_valid(const gchar *nickname, gboolean strict_mode) {
 				}
 				break;
 
+			/* '/' is used by common IRC bridges that spoof nicknames */
+			case '/':
+				if (strict_mode)
+					return FALSE;
+				break;
+
 			default:
 				if (strict_mode) {
 						/* only accept ascii characters in strict mode */


### PR DESCRIPTION
The forward slash is used by IRC bridges that follow the proposed IRCv3 spec at <https://github.com/ircv3/ircv3-specifications/pull/417>, such as Matterbridge and PyLink. See for example [Materbridge example configuration](https://github.com/42wim/matterbridge/blob/a0bca42a7ad98a37f4bdc4d7adc419471163edfb/matterbridge.toml.sample#L207)

Not accepting the character leads to messages being dropped silently, which very is confusing and looks like you're missing half the conversation.

The proposal was ultimately not accepted as an IRCv3 draft but it is being used in the wild and there's no downside to being compatible with it because `/` is not a special character the protocol. 